### PR TITLE
[Feature] Add query param 'hidden' at api/games endpoint

### DIFF
--- a/src/main/kotlin/com/unqueam/gamingplatform/application/dtos/gamesApiDtos.kt
+++ b/src/main/kotlin/com/unqueam/gamingplatform/application/dtos/gamesApiDtos.kt
@@ -20,7 +20,7 @@ data class GameRequest(
     @JsonProperty (value = "development_team")
     val developmentTeam: String,
     @JsonProperty (value = "is_hidden")
-    val isHidden: Boolean
+    val isHidden: Boolean?
 )
 
 data class DeveloperGameInput(

--- a/src/main/kotlin/com/unqueam/gamingplatform/application/dtos/gamesApiDtos.kt
+++ b/src/main/kotlin/com/unqueam/gamingplatform/application/dtos/gamesApiDtos.kt
@@ -18,7 +18,9 @@ data class GameRequest(
     val images: Set<GameImageInput>,
     val genres: Set<GenreInput>,
     @JsonProperty (value = "development_team")
-    val developmentTeam: String
+    val developmentTeam: String,
+    @JsonProperty (value = "is_hidden")
+    val isHidden: Boolean
 )
 
 data class DeveloperGameInput(
@@ -53,7 +55,9 @@ data class GameOutput(
     val developmentTeam: String,
     @JsonProperty (value = "rank_badge")
     val rankBadge: String,
-    val publisher: PublisherOutput
+    val publisher: PublisherOutput,
+    @JsonProperty (value = "is_hidden")
+    val isHidden: Boolean
 )
 
 data class PublisherOutput(

--- a/src/main/kotlin/com/unqueam/gamingplatform/application/http/GameController.kt
+++ b/src/main/kotlin/com/unqueam/gamingplatform/application/http/GameController.kt
@@ -37,9 +37,10 @@ class GameController {
     }
 
     @GetMapping
-    fun fetchGames(@RequestParam (required = false) username: String?): ResponseEntity<List<GameOutput>> {
+    fun fetchGames(@RequestParam (required = false) username: String?, @RequestParam (value = "hidden", required = false) hidden: Boolean?): ResponseEntity<List<GameOutput>> {
+        val getHiddenGamesParam = GetHiddenGamesParam(hidden)
         val usernameParam = Optional.ofNullable(username)
-        val games: List<GameOutput> = gameService.fetchGames(usernameParam)
+        val games: List<GameOutput> = gameService.fetchGames(usernameParam, getHiddenGamesParam)
         return ResponseEntity.status(HttpStatus.OK).body(games)
     }
 

--- a/src/main/kotlin/com/unqueam/gamingplatform/application/http/queryParams.kt
+++ b/src/main/kotlin/com/unqueam/gamingplatform/application/http/queryParams.kt
@@ -1,0 +1,15 @@
+package com.unqueam.gamingplatform.application.http
+
+class GetHiddenGamesParam(private val hiddenValue : Boolean?) {
+
+    /**
+     * It returns if should get all games (including hidden games).
+     * Example:
+     * Admin can fetch all games.
+     * PlatformUser (User) should only fetch no hidden games.
+     */
+    fun shouldFetchAllGames(): Boolean {
+        if (hiddenValue == null) { return false }
+        return hiddenValue
+    }
+}

--- a/src/main/kotlin/com/unqueam/gamingplatform/core/domain/Game.kt
+++ b/src/main/kotlin/com/unqueam/gamingplatform/core/domain/Game.kt
@@ -16,7 +16,8 @@ class Game(
     rankBadge: RankBadge,
     genres: Set<Genre>,
     developmentTeam: String,
-    publisher: PlatformUser
+    publisher: PlatformUser,
+    isHidden: Boolean
 ) {
 
     @Id
@@ -40,6 +41,7 @@ class Game(
     @Enumerated(EnumType.STRING)
     val genres: Set<Genre> = genres
     val developmentTeam: String = developmentTeam
+    val isHidden: Boolean = isHidden
 
     fun syncWith(updatedGame: Game): Game {
         return Game(
@@ -54,7 +56,8 @@ class Game(
             this.rankBadge,
             updatedGame.genres,
             updatedGame.developmentTeam,
-            this.publisher
+            this.publisher,
+            updatedGame.isHidden
         )
     }
 

--- a/src/main/kotlin/com/unqueam/gamingplatform/core/domain/Game.kt
+++ b/src/main/kotlin/com/unqueam/gamingplatform/core/domain/Game.kt
@@ -22,7 +22,7 @@ class Game(
 
     @Id
     @GeneratedValue (strategy = GenerationType.AUTO)
-    val id: Long? = anId
+    var id: Long? = anId
     @ManyToOne
     val publisher: PlatformUser = publisher
     var name: String = aName

--- a/src/main/kotlin/com/unqueam/gamingplatform/core/domain/GameBuilder.kt
+++ b/src/main/kotlin/com/unqueam/gamingplatform/core/domain/GameBuilder.kt
@@ -14,6 +14,7 @@ class GameBuilder {
     private var genres: Set<Genre> = setOf()
     private lateinit var developmentTeam: String
     private lateinit var publisher: PlatformUser
+    private var isHidden: Boolean = false
 
     fun developedBy(developers: Set<Developer>) : GameBuilder {
         this.developers = developers
@@ -22,6 +23,11 @@ class GameBuilder {
 
     fun publishedBy(publisher: PlatformUser) : GameBuilder {
         this.publisher = publisher
+        return this
+    }
+
+    fun isHidden(isHiddenValue: Boolean) : GameBuilder {
+        this.isHidden = isHiddenValue
         return this
     }
 
@@ -78,7 +84,8 @@ class GameBuilder {
             RankBadge.UNRANKED,
             genres,
             developmentTeam,
-            publisher
+            publisher,
+            isHidden
         )
     }
 }

--- a/src/main/kotlin/com/unqueam/gamingplatform/core/mapper/GameMapper.kt
+++ b/src/main/kotlin/com/unqueam/gamingplatform/core/mapper/GameMapper.kt
@@ -17,7 +17,7 @@ class GameMapper {
             .withLogoUrl(aGameRequest.logoUrl)
             .withDevelopmentTeam(aGameRequest.developmentTeam)
             .publishedBy(publisher)
-            .isHidden(aGameRequest.isHidden)
+            .isHidden(aGameRequest.isHidden ?: false)
             .build()
     }
 

--- a/src/main/kotlin/com/unqueam/gamingplatform/core/mapper/GameMapper.kt
+++ b/src/main/kotlin/com/unqueam/gamingplatform/core/mapper/GameMapper.kt
@@ -17,6 +17,7 @@ class GameMapper {
             .withLogoUrl(aGameRequest.logoUrl)
             .withDevelopmentTeam(aGameRequest.developmentTeam)
             .publishedBy(publisher)
+            .isHidden(aGameRequest.isHidden)
             .build()
     }
 
@@ -33,7 +34,8 @@ class GameMapper {
             mapToSet(aGame.genres) { GenreOutput(it.name, it.spanishName, it.englishName) },
             aGame.developmentTeam,
             aGame.rankBadge.name,
-            PublisherOutput(aGame.publisher.id!!, aGame.publisher.getUsername())
+            PublisherOutput(aGame.publisher.id!!, aGame.publisher.getUsername()),
+            aGame.isHidden
         )
     }
 

--- a/src/main/kotlin/com/unqueam/gamingplatform/core/services/IGameService.kt
+++ b/src/main/kotlin/com/unqueam/gamingplatform/core/services/IGameService.kt
@@ -2,13 +2,14 @@ package com.unqueam.gamingplatform.core.services
 
 import com.unqueam.gamingplatform.application.dtos.GameOutput
 import com.unqueam.gamingplatform.application.dtos.GameRequest
+import com.unqueam.gamingplatform.application.http.GetHiddenGamesParam
 import com.unqueam.gamingplatform.core.domain.PlatformUser
 import java.util.*
 
 interface IGameService {
 
     fun publishGame(gameRequest: GameRequest, publisher: PlatformUser)
-    fun fetchGames(username: Optional<String>): List<GameOutput>
+    fun fetchGames(username: Optional<String>, getHiddenGamesParam: GetHiddenGamesParam): List<GameOutput>
     fun fetchGameById(id: Long): GameOutput
     fun deleteGameById(id: Long)
     fun updateGameById(id: Long, updatedGameRequest: GameRequest, publisher: PlatformUser)

--- a/src/main/kotlin/com/unqueam/gamingplatform/core/services/implementation/GameService.kt
+++ b/src/main/kotlin/com/unqueam/gamingplatform/core/services/implementation/GameService.kt
@@ -2,6 +2,8 @@ package com.unqueam.gamingplatform.core.services.implementation
 
 import com.unqueam.gamingplatform.application.dtos.GameOutput
 import com.unqueam.gamingplatform.application.dtos.GameRequest
+import com.unqueam.gamingplatform.application.http.GetHiddenGamesParam
+import com.unqueam.gamingplatform.core.domain.Game
 import com.unqueam.gamingplatform.core.domain.PlatformUser
 import com.unqueam.gamingplatform.core.exceptions.Exceptions.GAME_NOT_FOUND_ERROR_MESSAGE
 import com.unqueam.gamingplatform.core.mapper.GameMapper
@@ -30,10 +32,17 @@ class GameService : IGameService {
         gameRepository.save(game)
     }
 
-    override fun fetchGames(username: Optional<String>): List<GameOutput> {
-        val games = username
-            .map { gameRepository.findGamesByUsername(it) }
-            .orElseGet { gameRepository.findAll() }
+    override fun fetchGames(username: Optional<String>, getHiddenGamesParam: GetHiddenGamesParam): List<GameOutput> {
+        lateinit var games: List<Game>
+        if (getHiddenGamesParam.shouldFetchAllGames()) {
+            games = username
+                .map { gameRepository.findGamesByUsername(it) }
+                .orElseGet { gameRepository.findAll() }
+        } else {
+            games = username
+                .map { gameRepository.findNoHiddenGamesByUsername(it) }
+                .orElseGet { gameRepository.findNoHiddenGames() }
+        }
         return games.map { gameMapper.mapToOutput(it) }
     }
 

--- a/src/main/kotlin/com/unqueam/gamingplatform/infrastructure/persistence/GameRepository.kt
+++ b/src/main/kotlin/com/unqueam/gamingplatform/infrastructure/persistence/GameRepository.kt
@@ -27,5 +27,13 @@ interface GameRepository : JpaRepository<Game, Long> {
     @EntityGraph(attributePaths=["developers", "images", "genres", "publisher"])
     @Query("from Game game where game.publisher.username = :username")
     fun findGamesByUsername(@Param("username") username: String): List<Game>
+
+    @EntityGraph(attributePaths=["developers", "images", "genres", "publisher"])
+    @Query("from Game game where game.publisher.username = :username and game.isHidden = false")
+    fun findNoHiddenGamesByUsername(username: String): List<Game>
+
+    @EntityGraph(attributePaths=["developers", "images", "genres", "publisher"])
+    @Query("from Game game where game.isHidden = false")
+    fun findNoHiddenGames(): List<Game>
 }
 

--- a/src/main/kotlin/com/unqueam/gamingplatform/infrastructure/seeders/DatabaseSeeder.kt
+++ b/src/main/kotlin/com/unqueam/gamingplatform/infrastructure/seeders/DatabaseSeeder.kt
@@ -4,6 +4,7 @@ import com.unqueam.gamingplatform.application.dtos.DeveloperGameInput
 import com.unqueam.gamingplatform.application.dtos.GameImageInput
 import com.unqueam.gamingplatform.application.dtos.GameRequest
 import com.unqueam.gamingplatform.application.dtos.GenreInput
+import com.unqueam.gamingplatform.application.http.GetHiddenGamesParam
 import com.unqueam.gamingplatform.core.domain.*
 import com.unqueam.gamingplatform.core.services.IGameService
 import com.unqueam.gamingplatform.infrastructure.persistence.UserRepository
@@ -35,8 +36,8 @@ class DatabaseSeeder {
     @Transactional
     @EventListener
     fun seed(event: ContextRefreshedEvent) {
-        val userHulk: PlatformUser = loadUsers().get(1)
-        if (gameService.fetchGames(Optional.empty()).isEmpty()) {
+        val userHulk: PlatformUser = loadUsers().get(2)
+        if (gameService.fetchGames(Optional.empty(), GetHiddenGamesParam(true)).isEmpty()) {
             createGames().forEach { gameService.publishGame(it, userHulk) }
             loadViewsForGameWithId(3, 18)
             loadViewsForGameWithId(4, 70)
@@ -47,14 +48,15 @@ class DatabaseSeeder {
     }
 
     private fun loadUsers(): List<PlatformUser> {
-        val admin: PlatformUser = PlatformUser(null, "admin", passwordEncoder.encode("admin"), "nico@gmail.com", Role.ADMIN)
+        val adminn: PlatformUser = PlatformUser(null, "admin.n", passwordEncoder.encode("admin"), "nicolas.demaio19@gmail.com", Role.ADMIN)
+        val adminj: PlatformUser = PlatformUser(null, "admin.j", passwordEncoder.encode("admin"), "trejojulian998@gmail.com", Role.ADMIN)
 
         val user1: PlatformUser = PlatformUser(null, "hulk", passwordEncoder.encode("hulk123"), "hulk@gmail.com", Role.DEVELOPER)
         val user2: PlatformUser = PlatformUser(null, "spider_man", passwordEncoder.encode("spider_man123"), "spider_man@gmail.com", Role.USER)
         val user3: PlatformUser = PlatformUser(null, "ant_man", passwordEncoder.encode("ant_man123"), "ant_man@gmail.com", Role.USER)
         val user4: PlatformUser = PlatformUser(null, "falcon", passwordEncoder.encode("falcon123"), "falcon@gmail.com", Role.USER)
 
-        return userRepository.saveAll(mutableListOf(admin, user1, user2, user3, user4))
+        return userRepository.saveAll(mutableListOf(adminn, adminj, user1, user2, user3, user4))
     }
 
     private fun createGames(): List<GameRequest> {
@@ -206,7 +208,8 @@ class DatabaseSeeder {
                     GameImageInput("https://blog.latam.playstation.com/tachyon/sites/3/2022/06/3d2d01626430e2ee9117d81b834970fa6242e10f.jpg")
                 ),
                 setOf(GenreInput(Genre.ACTION.name)),
-                "Blizzard"
+                "Blizzard",
+                true
             ),
             createGame(
                 "KOTOR 2",
@@ -221,7 +224,8 @@ class DatabaseSeeder {
                     GameImageInput("https://blog.latam.playstation.com/tachyon/sites/3/2022/06/3d2d01626430e2ee9117d81b834970fa6242e10f.jpg")
                 ),
                 setOf(GenreInput(Genre.ACTION.name)),
-                "Blizzard"
+                "Blizzard",
+                true
             ),
         )
     }
@@ -235,7 +239,8 @@ class DatabaseSeeder {
         developers: Set<DeveloperGameInput>,
         images: Set<GameImageInput>,
         genres: Set<GenreInput>,
-        developmentTeam: String
+        developmentTeam: String,
+        isHidden: Boolean? = false
     ): GameRequest {
         return GameRequest(
             name,
@@ -246,7 +251,8 @@ class DatabaseSeeder {
             developers,
             images,
             genres,
-            developmentTeam
+            developmentTeam,
+            isHidden!!
         )
     }
 

--- a/src/test/kotlin/com/unqueam/gamingplatform/application/http/GameControllerTest.kt
+++ b/src/test/kotlin/com/unqueam/gamingplatform/application/http/GameControllerTest.kt
@@ -3,30 +3,30 @@ package com.unqueam.gamingplatform.application.http
 import com.unqueam.gamingplatform.application.auth.AuthContextHelper
 import com.unqueam.gamingplatform.core.domain.Game
 import com.unqueam.gamingplatform.core.domain.PlatformUser
-import com.unqueam.gamingplatform.core.services.implementation.GameService
+import com.unqueam.gamingplatform.core.services.IGameService
+import com.unqueam.gamingplatform.resources.InMemoryGameService
 import com.unqueam.gamingplatform.utils.GameRequestTestResource
-import com.unqueam.gamingplatform.utils.GameTestResource
 import com.unqueam.gamingplatform.utils.UserTestResource
 import io.mockk.every
 import io.mockk.mockkObject
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
 import org.springframework.http.HttpStatus
-import java.util.*
 
 class GameControllerTest {
 
-    private lateinit var gameService: GameService
+    private lateinit var gameService: IGameService
     private lateinit var gameController: GameController
     private lateinit var publisher: PlatformUser
+    private lateinit var getHiddenGamesParam: GetHiddenGamesParam
 
     @BeforeEach
     fun setup() {
-        gameService = mock(GameService::class.java)
+        gameService = InMemoryGameService()
         gameController = GameController(gameService)
         publisher = UserTestResource.buildUser()
+        getHiddenGamesParam = GetHiddenGamesParam(true)
 
         mockkObject(AuthContextHelper)
         every { AuthContextHelper.getAuthenticatedUser() } returns publisher
@@ -36,44 +36,38 @@ class GameControllerTest {
     fun `can publish a game`() {
         val gameRequest = GameRequestTestResource.buildGameRequest()
 
-        `when`(gameService.publishGame(gameRequest, publisher)).then { }
-
         val response = gameController.publishGame(gameRequest)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.CREATED)
-        verify(gameService).publishGame(gameRequest, publisher)
     }
 
     @Test
     fun `should fetch games`() {
-        `when`(gameService.fetchGames(Optional.of("username"))).thenReturn(listOf())
-        val response = gameController.fetchGames("username")
+        val response = gameController.fetchGames("username", true)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         assertThat(response.body).isEqualTo(listOf<Game>())
-        verify(gameService).fetchGames(Optional.of("username"))
     }
 
     @Test
     fun `should fetch game by id`() {
         val id = 1L
-        val game = GameTestResource.buildGameOutputWithId(id)
-        `when`(gameService.fetchGameById(id)).thenReturn(game)
+        val game = GameRequestTestResource.buildGameRequest()
+
+        gameController.publishGame(game)
+
         val response = gameController.fetchGameById(id)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body).isEqualTo(game)
-        verify(gameService).fetchGameById(id)
+        assertThat(response.body?.name).isEqualTo(game.name)
     }
 
     @Test
     fun `should delete a game by id`() {
         val id = 1L
-        `when`(gameService.deleteGameById(id)).then { }
         val response = gameController.deleteGameById(id)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        verify(gameService).deleteGameById(id)
     }
 
     @Test
@@ -81,10 +75,10 @@ class GameControllerTest {
         val id = 1L
         val gameRequest = GameRequestTestResource.buildGameRequest()
 
-        `when`(gameService.updateGameById(id, gameRequest, publisher)).then { }
+        gameController.publishGame(gameRequest)
+
         val response = gameController.updateGameById(id, gameRequest)
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        verify(gameService).updateGameById(id, gameRequest, publisher)
     }
 }

--- a/src/test/kotlin/com/unqueam/gamingplatform/core/services/implementation/GameServiceTest.kt
+++ b/src/test/kotlin/com/unqueam/gamingplatform/core/services/implementation/GameServiceTest.kt
@@ -1,5 +1,6 @@
 package com.unqueam.gamingplatform.core.services.implementation
 
+import com.unqueam.gamingplatform.application.http.GetHiddenGamesParam
 import com.unqueam.gamingplatform.core.domain.Game
 import com.unqueam.gamingplatform.core.domain.PlatformUser
 import com.unqueam.gamingplatform.core.mapper.GameMapper
@@ -49,7 +50,7 @@ class GameServiceTest {
         val games = listOf<Game>()
         `when`(gameRepository.findAll()).thenReturn(games)
 
-        val retrievedGames = gameService.fetchGames(Optional.empty())
+        val retrievedGames = gameService.fetchGames(Optional.empty(), GetHiddenGamesParam(true))
 
         assertThat(retrievedGames).isEqualTo(games)
     }

--- a/src/test/kotlin/com/unqueam/gamingplatform/resources/InMemoryGameService.kt
+++ b/src/test/kotlin/com/unqueam/gamingplatform/resources/InMemoryGameService.kt
@@ -1,0 +1,48 @@
+package com.unqueam.gamingplatform.resources
+
+import com.unqueam.gamingplatform.application.dtos.GameOutput
+import com.unqueam.gamingplatform.application.dtos.GameRequest
+import com.unqueam.gamingplatform.application.http.GetHiddenGamesParam
+import com.unqueam.gamingplatform.core.domain.Game
+import com.unqueam.gamingplatform.core.domain.PlatformUser
+import com.unqueam.gamingplatform.core.exceptions.Exceptions.GAME_NOT_FOUND_ERROR_MESSAGE
+import com.unqueam.gamingplatform.core.mapper.GameMapper
+import com.unqueam.gamingplatform.core.services.IGameService
+import jakarta.persistence.EntityNotFoundException
+import java.util.*
+
+class InMemoryGameService : IGameService {
+
+    private var gamesCounter: Long = 1
+    private var gameRepository: MutableList<Game> = mutableListOf()
+    private val gameMapper: GameMapper = GameMapper()
+
+    override fun publishGame(gameRequest: GameRequest, publisher: PlatformUser) {
+        val game = gameMapper.mapToInput(gameRequest, publisher)
+        game.id = gamesCounter
+        gamesCounter++
+        gameRepository.add(game)
+    }
+
+    override fun fetchGames(username: Optional<String>, getHiddenGamesParam: GetHiddenGamesParam): List<GameOutput> {
+        return gameRepository.map { gameMapper.mapToOutput(it) }
+    }
+
+    override fun fetchGameById(id: Long): GameOutput {
+        val game = gameRepository.find { it.id == id } ?: throw EntityNotFoundException(GAME_NOT_FOUND_ERROR_MESSAGE.format(id))
+        return gameMapper.mapToOutput(game)
+    }
+
+    override fun deleteGameById(id: Long) {
+        gameRepository = gameRepository.filter { it -> it.id != id }.toMutableList()
+    }
+
+    override fun updateGameById(id: Long, updatedGameRequest: GameRequest, publisher: PlatformUser) {
+        val updatedGameFromRequest = gameMapper.mapToInput(updatedGameRequest, publisher)
+
+        val storedGame = gameRepository.find { it.id == id } ?: throw EntityNotFoundException(GAME_NOT_FOUND_ERROR_MESSAGE.format(id))
+
+        storedGame.syncWith(updatedGameFromRequest)
+    }
+
+}

--- a/src/test/kotlin/com/unqueam/gamingplatform/utils/GameRequestTestResource.kt
+++ b/src/test/kotlin/com/unqueam/gamingplatform/utils/GameRequestTestResource.kt
@@ -16,7 +16,8 @@ object GameRequestTestResource {
             setOf(),
             setOf(),
             setOf(),
-            "developmentTeam"
+            "developmentTeam",
+            null
         )
     }
 

--- a/src/test/kotlin/com/unqueam/gamingplatform/utils/GameTestResource.kt
+++ b/src/test/kotlin/com/unqueam/gamingplatform/utils/GameTestResource.kt
@@ -21,7 +21,8 @@ object GameTestResource {
             RankBadge.UNRANKED,
             setOf(),
             "developmentTeam",
-            UserTestResource.buildUser()
+            UserTestResource.buildUser(),
+            false
         )
     }
 


### PR DESCRIPTION
### Descripción

Damos la posibilidad de enviar mediante el endpoint `GET /api/games` un query param hidden que acepta valores booleanos.

`hidden = true/false`

En caso de no enviarlo, el valor por defecto sera **_false_**.

Trae los juegos que estan ocultos por sus dueños.